### PR TITLE
Added name attribute to select

### DIFF
--- a/live-examples/html-examples/forms/select.html
+++ b/live-examples/html-examples/forms/select.html
@@ -1,6 +1,6 @@
 <label for="pet-select">Choose a pet:</label>
 
-<select id="pet-select">
+<select name="pets" id="pet-select">
     <option value="">--Please choose an option--</option>
     <option value="dog">Dog</option>
     <option value="cat">Cat</option>


### PR DESCRIPTION
The description for the select contains the following text: "The above example shows typical <select> usage. It is given an id attribute to enable it to be associated with a <label> for accessibility purposes, as well as a name attribute to represent the name of the associated data point submitted to the server. "

The name attribute mentioned in the text is missing in the example.